### PR TITLE
Enable Fortran bindings on OSX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,13 +9,11 @@ if [ "$(uname)" == "Darwin" ]; then
     export MACOSX_DEPLOYMENT_TARGET="10.9"
     export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
     export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
-    OPTS="--disable-mpi-fortran"
 fi
 
 
 ./configure --prefix=$PREFIX \
-            --disable-dependency-tracking \
-            $OPTS
+            --disable-dependency-tracking
 
 
 make -j $CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,20 @@ build:
 requirements:
     build:
         - perl
-        - gcc  # [linux]
+        - gcc  # [not win]
     run:
+        - libgfortran  # [osx]
         - libgcc  # [linux]
 
 test:
+
+    requires:
+        - gcc  # [not win]
+
     files:
         - tests/helloworld.c
         - tests/helloworld.cxx
+        - tests/helloworld.f90
     #commands:
         #- conda inspect linkages -n _test openmpi  # [not win]
         #- conda inspect objects -n _test openmpi  # [osx]

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -16,13 +16,17 @@ mpicc --allow-run-as-root -show
 command -v mpicxx
 mpicxx --allow-run-as-root -show
 
-# FIXME: No Fortran support on OS X yet.
-if [[ $(uname) == Linux ]]; then
-  command -v mpif90
-  mpif90 --allow-run-as-root -show
-fi
+command -v mpif90
+mpif90 --allow-run-as-root -show
 
 command -v mpiexec
+
 mpicc $RECIPE_DIR/tests/helloworld.c -o helloworld_c
 mpiexec -mca plm isolated --allow-run-as-root -n 4 helloworld_c
+
+# mpicxx $RECIPE_DIR/tests/helloworld.cxx -o helloworld_cxx
+# mpiexec -mca plm isolated --allow-run-as-root -n 4 helloworld_cxx
+
+mpif90 $RECIPE_DIR/tests/helloworld.f90 -o helloworld_f90
+mpiexec -mca plm isolated --allow-run-as-root -n 4 helloworld_f90
 


### PR DESCRIPTION
This is a work in progress and isn't ready for review