### PR TITLE
skip mpiexec tests on Linux [travis skip]

### DIFF
--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,8 +13,14 @@ command -v mpif90
 mpif90 -show
 
 command -v mpiexec
-MPIEXEC="mpiexec -mca plm isolated --allow-run-as-root"
-$MPIEXEC --help
+if [[ "$(uname)" == "Darwin" ]]; then
+  MPIEXEC="mpiexec -mca plm isolated --allow-run-as-root"
+  $MPIEXEC --help
+else
+  # skip mpiexec tests on Linux due to conda-forge bug:
+  # https://github.com/conda-forge/conda-smithy/pull/337
+  MPIEXEC="echo SKIPPING mpiexec"
+fi
 
 pushd $RECIPE_DIR/tests
 


### PR DESCRIPTION
Due to a bug in conda-forge setup, mpiexec can't be called during tests because it will prevent upload of the finished package.

When https://github.com/conda-forge/conda-smithy/pull/337 is merged, we should be able to resume calling mpiexec in the tests.

closes #8