### PR TITLE
mpi metapackage

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,5 +11,5 @@ export LIBRARY_PATH="$PREFIX/lib"
             --enable-mpi-cxx \
             --enable-mpi-fortran
 
-make
+make -j"${CPU_COUNT:-1}"
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     number: {{ build }}
     skip: True  # [win]
     track_features:
-      - mpi_openmpi
+      - openmpi
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
     number: {{ build }}
     skip: True  # [win]
-    track_features:
+    features:
       - openmpi
 
 requirements:
@@ -26,6 +26,7 @@ requirements:
     run:
         - libgcc  # [linux]
         - libgfortran  # [osx]
+        - mpi
 
 test:
     requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,6 @@ source:
 build:
     number: {{ build }}
     skip: True  # [win]
-    features:
-      - openmpi
 
 requirements:
     build:
@@ -26,7 +24,7 @@ requirements:
     run:
         - libgcc  # [linux]
         - libgfortran  # [osx]
-        - mpi
+        - mpi 1.0 openmpi
 
 test:
     requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = '3.0.0' %}
 {% set sha256 = 'f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7' %}
 {% set major = version.rpartition('.')[0] %}
@@ -15,6 +15,8 @@ source:
 build:
     number: {{ build }}
     skip: True  # [win]
+    track_features:
+      - mpi_openmpi
 
 requirements:
     build:


### PR DESCRIPTION
Implement proposal for https://github.com/conda-forge/staged-recipes/pull/1501

Should probably wait until that one is resolved before merging.

<del>Tracking here is required for downstream packages to define mpi_openmpi feature.</del>

Following updates in the discussion, mpi mpkg tracks the feature upstream (for mutual exclusivity) while provider *has* the feature.