### PR TITLE
trigger rebuild to get libgfortran dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 2
+    number: 3
     skip: True  # [win]
     run_exports:
         - {{ pin_subpackage('openmpi', min_pin='x.x', max_pin='x.x') }}


### PR DESCRIPTION
get fixes from toolchain 2.1.6 linking libgfortran instead of libgfortran-ng

same as https://github.com/conda-forge/mpich-feedstock/pull/23