### PR TITLE
Add patch to prevent hanging during libnetcdf install

### DIFF
--- a/recipe/0001-common-ompio-fix-calculation-in-simple-grouping-opti.patch
+++ b/recipe/0001-common-ompio-fix-calculation-in-simple-grouping-opti.patch
@@ -1,0 +1,74 @@
+From ad5d0df4e91d66efa5b69e8388f7ed0b4b6a1d09 Mon Sep 17 00:00:00 2001
+From: Edgar Gabriel <egabriel@central.uh.edu>
+Date: Tue, 29 Oct 2019 12:30:41 -0500
+Subject: [PATCH] common/ompio: fix calculation in simple-grouping option
+
+This is based on a bug reported on the mailing list using a netcdf testcase.
+The problem occurs if processes are using a custom file view, but on some
+of them it appears as if the default file view is being used. Because of that,
+the simple-grouping option lead to different number of aggregators used on different
+processes, and ultimately to a deadlock. This patch fixes the problem by not using
+the file_view size anymore for the calculation in the simple-grouping option,
+but the contiguous chunk size (which is identical on all processes).
+
+Fixes issue #7109
+
+Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>
+---
+ ompi/mca/common/ompio/common_ompio_aggregators.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/ompi/mca/common/ompio/common_ompio_aggregators.c b/ompi/mca/common/ompio/common_ompio_aggregators.c
+index 5a570d8e00..fdde4dee96 100644
+--- a/ompi/mca/common/ompio/common_ompio_aggregators.c
++++ b/ompi/mca/common/ompio/common_ompio_aggregators.c
+@@ -126,17 +126,17 @@ int mca_common_ompio_simple_grouping(ompio_file_t *fh,
+     }
+ 
+     P_a = 1;
+-    time_prev = cost_calc ( fh->f_size, P_a, fh->f_view_size, (size_t) fh->f_bytes_per_agg, mode );
++    time_prev = cost_calc ( fh->f_size, P_a, fh->f_cc_size, (size_t) fh->f_bytes_per_agg, mode );
+     P_a_prev = P_a;
+     for ( P_a = incr; P_a <= fh->f_size; P_a += incr ) {
+-	time = cost_calc ( fh->f_size, P_a, fh->f_view_size, (size_t) fh->f_bytes_per_agg, mode );
++	time = cost_calc ( fh->f_size, P_a, fh->f_cc_size, (size_t) fh->f_bytes_per_agg, mode );
+ 	dtime_abs = (time_prev - time);
+ 	dtime = dtime_abs / time_prev;
+ 	dtime_diff = ( P_a == incr ) ? dtime : (dtime_prev - dtime);
+ #ifdef OMPIO_DEBUG
+ 	if ( 0 == fh->f_rank  ){
+ 	    printf(" d_p = %ld P_a = %d time = %lf dtime = %lf dtime_abs =%lf dtime_diff=%lf\n", 
+-		   fh->f_view_size, P_a, time, dtime, dtime_abs, dtime_diff );
++		   fh->f_cc_size, P_a, time, dtime, dtime_abs, dtime_diff );
+ 	}
+ #endif
+ 	if ( dtime_diff < dtime_threshold ) {
+@@ -171,7 +171,7 @@ int mca_common_ompio_simple_grouping(ompio_file_t *fh,
+     num_groups = P_a_prev;
+ #ifdef OMPIO_DEBUG
+     printf(" For P=%d d_p=%ld b_c=%d threshold=%f chosen P_a = %d \n", 
+-	   fh->f_size, fh->f_view_size, fh->f_bytes_per_agg, dtime_threshold, P_a_prev);
++	   fh->f_size, fh->f_cc_size, fh->f_bytes_per_agg, dtime_threshold, P_a_prev);
+ #endif
+     
+     /* Cap the maximum number of aggregators.*/
+@@ -183,6 +183,7 @@ int mca_common_ompio_simple_grouping(ompio_file_t *fh,
+     }
+     
+     *num_groups_out = num_groups;
++
+     return mca_common_ompio_forced_grouping ( fh, num_groups, contg_groups);
+ }
+ 
+@@ -576,7 +577,7 @@ int mca_common_ompio_create_groups(ompio_file_t *fh,
+         opal_output (1, "mca_common_ompio_create_groups: error in mca_common_ompio_prepare_to_group\n");
+         goto exit;
+     }
+-
++    
+     switch(ompio_grouping_flag){
+ 
+         case OMPIO_SPLIT:
+-- 
+2.23.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   fn: openmpi-{{ version }}.tar.bz2
   url: https://www.open-mpi.org/software/ompi/v{{ major }}/downloads/openmpi-{{ version }}.tar.bz2
   sha256: 900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057
+  patches:
+    - 0001-common-ompio-fix-calculation-in-simple-grouping-opti.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 outputs:


### PR DESCRIPTION
See: https://github.com/open-mpi/ompi/pull/7122

This patch is needed to address build issues in https://github.com/conda-forge/libnetcdf-feedstock/pull/90, https://github.com/conda-forge/libnetcdf-feedstock/pull/91 and https://github.com/conda-forge/libnetcdf-feedstock/pull/92

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
