### PR TITLE
Remove C++ bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 matrix:
   include:
     - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
-      os: linux-ppc64le
+      os: linux
+      arch: ppc64le
 
 script:
   - export CI=travis

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Current build status
 <table><tr>
     <td>Travis</td>
     <td>
-      <a href="https://travis-ci.org/conda-forge/openmpi-feedstock">
-        <img alt="macOS" src="https://img.shields.io/travis/conda-forge/openmpi-feedstock/master.svg?label=macOS">
+      <a href="https://travis-ci.com/conda-forge/openmpi-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/openmpi-feedstock/master.svg?label=macOS">
       </a>
     </td>
   </tr><tr>
@@ -133,7 +133,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -15,6 +15,7 @@ export FC=$(basename "$FC")
 if [ $(uname) == Darwin ]; then
     if [[ ! -z "$CONDA_BUILD_SYSROOT" ]]; then
         export CFLAGS="$CFLAGS -isysroot $CONDA_BUILD_SYSROOT"
+        export CXXFLAGS="$CXXFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     fi
     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 fi

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -15,7 +15,6 @@ export FC=$(basename "$FC")
 if [ $(uname) == Darwin ]; then
     if [[ ! -z "$CONDA_BUILD_SYSROOT" ]]; then
         export CFLAGS="$CFLAGS -isysroot $CONDA_BUILD_SYSROOT"
-        export CXXFLAGS="$CXXFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     fi
     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
 
@@ -32,7 +31,6 @@ export LIBRARY_PATH="$PREFIX/lib"
 
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
-            --enable-mpi-cxx \
             --enable-mpi-fortran \
             --disable-wrapper-rpath \
             --disable-wrapper-runpath \

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -17,14 +17,6 @@ if [ $(uname) == Darwin ]; then
         export CFLAGS="$CFLAGS -isysroot $CONDA_BUILD_SYSROOT"
     fi
     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
-
-    # fix #include <version> issue on mac
-    # VERSION (no ext) is included from the top-level repo dir for c++
-    # xref: https://github.com/open-mpi/ompi/issues/7155
-    # fix by renaming VERSION to VERSION.sh
-    # grep -l '/VERSION' -R . | xargs sed -i "" s@/VERSION@/VERSION.sh@g
-    mv -v VERSION VERSION.sh
-    sed -i "" s@/VERSION@/VERSION.sh@g configure
 fi
 
 export LIBRARY_PATH="$PREFIX/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
-        - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
         - make  # [unix]
         - perl 5.26.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-common-ompio-fix-calculation-in-simple-grouping-opti.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
         - make  # [unix]
         - perl 5.26.2

--- a/recipe/tests/helloworld.cxx
+++ b/recipe/tests/helloworld.cxx
@@ -3,12 +3,16 @@
 
 int main(int argc, char *argv[])
 {
-  MPI::Init();
+  int provided, size, rank, len;
+  char name[MPI_MAX_PROCESSOR_NAME];
 
-  int size = MPI::COMM_WORLD.Get_size();
-  int rank = MPI::COMM_WORLD.Get_rank();
-  int len; char name[MPI_MAX_PROCESSOR_NAME];
-  MPI::Get_processor_name(name, len);
+  MPI_Init(&argc, &argv);
+
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Get_processor_name(name, &len);
+
+  printf("Hello, World! I am process %d of %d on %s.\n", rank, size, name);
 
   std::cout <<
     "Hello, World! " <<
@@ -17,6 +21,6 @@ int main(int argc, char *argv[])
     " on  "          << name <<
     "."              << std::endl;
 
-  MPI::Finalize();
+  MPI_Finalize();
   return 0;
 }

--- a/recipe/tests/helloworld.cxx
+++ b/recipe/tests/helloworld.cxx
@@ -12,8 +12,6 @@ int main(int argc, char *argv[])
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Get_processor_name(name, &len);
 
-  printf("Hello, World! I am process %d of %d on %s.\n", rank, size, name);
-
   std::cout <<
     "Hello, World! " <<
     "I am process "  << rank <<


### PR DESCRIPTION
Based on discussion in https://github.com/open-mpi/ompi/pull/7169 it seems that openmpi maintainers view the c++ bindings as deprecated by a decade and plan for its removal in 5.x, so maybe we shouldn't package it.

Is anyone using the mpi c++ bindings? cc @astrofrog @isuruf

Reverts #3