### PR TITLE
ENH add external build for linking against system MPI libs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7fortran_compiler_version7:
-        CONFIG: linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7fortran_compiler_version7
+      linux_64_cuda_compiler_version10.2mpi_typeconda:
+        CONFIG: linux_64_cuda_compiler_version10.2mpi_typeconda
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
+      linux_64_cuda_compiler_version10.2mpi_typeexternal:
+        CONFIG: linux_64_cuda_compiler_version10.2mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_mpi_typeconda:
+        CONFIG: osx_64_mpi_typeconda
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_mpi_typeexternal:
+        CONFIG: osx_64_mpi_typeexternal
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpi_typeconda:
+        CONFIG: osx_arm64_mpi_typeconda
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_mpi_typeexternal:
+        CONFIG: osx_arm64_mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_cuda_compiler_version10.2mpi_typeconda.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2mpi_typeconda.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+mpi_type:
+- conda
 pin_run_as_build:
   zlib:
     max_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version10.2mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2mpi_typeexternal.yaml
@@ -1,0 +1,40 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-cuda:10.2
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '7'
+mpi_type:
+- external
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_mpi_typeconda.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeconda.yaml
@@ -24,6 +24,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '10'
+mpi_type:
+- conda
 pin_run_as_build:
   zlib:
     max_pin: x.x

--- a/.ci_support/linux_aarch64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeexternal.yaml
@@ -1,9 +1,13 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '12'
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,23 +15,28 @@ channel_targets:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '12'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '9'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '10'
+mpi_type:
+- external
 pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_mpi_typeconda.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeconda.yaml
@@ -1,9 +1,9 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '12'
+- '10'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,23 +11,28 @@ channel_targets:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '12'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '10'
+mpi_type:
+- conda
 pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
@@ -1,0 +1,38 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '10'
+mpi_type:
+- external
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+  - cuda_compiler_version
+  - cdt_name
+  - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_mpi_typeconda.yaml
+++ b/.ci_support/osx_64_mpi_typeconda.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '12'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '12'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi_type:
+- conda
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_mpi_typeexternal.yaml
+++ b/.ci_support/osx_64_mpi_typeexternal.yaml
@@ -1,9 +1,9 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_name:
-- cos7
+- '12'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,26 +11,25 @@ channel_targets:
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- '12'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mpi_type:
+- external
 pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/osx_arm64_mpi_typeconda.yaml
+++ b/.ci_support/osx_arm64_mpi_typeconda.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '12'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '12'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi_type:
+- conda
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_mpi_typeexternal.yaml
+++ b/.ci_support/osx_arm64_mpi_typeexternal.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '12'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '12'
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '11'
+macos_machine:
+- arm64-apple-darwin20.0.0
+mpi_type:
+- external
+pin_run_as_build:
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - fortran_compiler_version
+zlib:
+- '1.2'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astrofrog-conda-forge @bekozi @dalcinl @leofang @minrk @msarahan @ocefpaf
+* @astrofrog-conda-forge @beckermr @bekozi @dalcinl @leofang @minrk @msarahan @ocefpaf

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,22 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_aarch64_ UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_mpi_typeconda UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal
 
-    - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_aarch64_mpi_typeexternal UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpi_typeconda UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+      dist: focal
+
+    - env: CONFIG=linux_ppc64le_mpi_typeexternal UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal

--- a/README.md
+++ b/README.md
@@ -43,38 +43,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7fortran_compiler_version7</td>
+              <td>linux_64_cuda_compiler_version10.2mpi_typeconda</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_c_compiler_version7cuda_compiler_version10.2cxx_compiler_version7fortran_compiler_version7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_cuda_compiler_version10.2mpi_typeconda" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_cuda_compiler_version10.2mpi_typeexternal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_cuda_compiler_version10.2mpi_typeexternal" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_aarch64_mpi_typeconda</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpi_typeconda" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_mpi_typeexternal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_mpi_typeexternal" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_ppc64le_mpi_typeconda</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpi_typeconda" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_mpi_typeexternal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_ppc64le_mpi_typeexternal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpi_typeconda</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpi_typeconda" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_mpi_typeexternal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_64_mpi_typeexternal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpi_typeconda</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpi_typeconda" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_mpi_typeexternal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_mpi_typeexternal" alt="variant">
                 </a>
               </td>
             </tr>
@@ -210,6 +245,7 @@ Feedstock Maintainers
 =====================
 
 * [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
+* [@beckermr](https://github.com/beckermr/)
 * [@bekozi](https://github.com/bekozi/)
 * [@dalcinl](https://github.com/dalcinl/)
 * [@leofang](https://github.com/leofang/)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+mpi_type:
+  - external
+  - conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,11 @@
 {% set version = "4.1.3" %}
 {% set major = version.rpartition('.')[0] %}
+{% set build = 1 %}
+
+# give conda package a higher build number
+{% if mpi_type == 'conda' %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   # must not match any outputs for requirements to be handled correctly
@@ -12,11 +18,23 @@ source:
   sha256: 3d81d04c54efb55d3871a465ffb098d8d72c1f48ff1cbaf2580eb058567c0a3b
 
 build:
-  number: 0
+  number: {{ build }}
   # remember to bump the CUDA version in build-mpi.sh too!
   skip: true  # [win or (linux64 and cuda_compiler_version != '10.2') or ((aarch64 or ppc64le) and cuda_compiler_version not in (undefined, "None"))]
 
 outputs:
+  {% if mpi_type == 'external' %}
+  - name: openmpi
+    string: {{ mpi_type }}_{{ build }}
+    track_features:
+      - openmpi_{{ mpi_type }}
+    requirements:
+      run:
+        - mpi 1.0 openmpi
+    test:
+      commands:
+        - echo "It works!"
+  {% else %}
   - name: openmpi
     script: build-mpi.sh
     build:
@@ -104,6 +122,7 @@ outputs:
         - mpiexec.sh
         - tests/helloworld.f
         - tests/helloworld.f90
+  {% endif %}
 
 about:
   home: https://www.open-mpi.org/
@@ -127,3 +146,4 @@ extra:
     - minrk
     - msarahan
     - ocefpaf
+    - beckermr


### PR DESCRIPTION
This PR adds a dummy package with lower solver priority to allow for users at HPC systems to link their packages in conda compiled against openmpi to the system openmpi libraries. This is a requirement for most HPC systems. The other major mpi distribution in conda-forge, `mpich` already supports this. See PR https://github.com/conda-forge/mpich-feedstock/pull/44. 

We'll need to change the docs which mentions this for mpich here: https://conda-forge.org/docs/user/tipsandtricks.html#using-external-message-passing-interface-mpi-libraries

Closes #90 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


