### PR TITLE
Use default compiler versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cuda_compiler_version10.2mpi_typeconda:
-        CONFIG: linux_64_cuda_compiler_version10.2mpi_typeconda
+      linux_64_mpi_typeconda:
+        CONFIG: linux_64_mpi_typeconda
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
-      linux_64_cuda_compiler_version10.2mpi_typeexternal:
-        CONFIG: linux_64_cuda_compiler_version10.2mpi_typeexternal
+      linux_64_mpi_typeexternal:
+        CONFIG: linux_64_mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-cuda:10.2
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_mpi_typeconda.yaml
+++ b/.ci_support/linux_64_mpi_typeconda.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '10'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,15 +15,15 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '10'
 mpi_type:
-- external
+- conda
 pin_run_as_build:
   zlib:
     max_pin: x.x
@@ -33,8 +33,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_mpi_typeexternal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '10'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,15 +15,15 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '10'
 mpi_type:
-- conda
+- external
 pin_run_as_build:
   zlib:
     max_pin: x.x
@@ -33,8 +33,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_mpi_typeconda.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeconda.yaml
@@ -35,8 +35,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeexternal.yaml
@@ -35,8 +35,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_mpi_typeconda.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeconda.yaml
@@ -31,8 +31,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
@@ -31,8 +31,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-  - cuda_compiler_version
-  - cdt_name
-  - docker_image
 zlib:
 - '1.2'

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cuda_compiler_version10.2mpi_typeconda</td>
+              <td>linux_64_mpi_typeconda</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_cuda_compiler_version10.2mpi_typeconda" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_mpi_typeconda" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compiler_version10.2mpi_typeexternal</td>
+              <td>linux_64_mpi_typeexternal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_cuda_compiler_version10.2mpi_typeexternal" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux_64_mpi_typeexternal" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -21,10 +21,8 @@ if [[ "$target_platform" == osx-* ]]; then
     fi
 fi
 
-if [[ $cuda_compiler_version == 10.2 ]]; then
+if [[ ! -z $cuda_compiler_version && $cuda_compiler_version != "None" ]]; then
     build_with_cuda="--with-cuda --with-ucx=$PREFIX"
-else
-    build_with_cuda=""
 fi
 
 if [[ $CONDA_BUILD_CROSS_COMPILATION == "1"  && $target_platform == osx-arm64 ]]; then
@@ -149,7 +147,7 @@ export LIBRARY_PATH="$PREFIX/lib"
             --with-wrapper-fcflags="-I$PREFIX/include" \
             --with-wrapper-ldflags="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib" \
             --with-sge \
-            $build_with_cuda
+            ${build_with_cuda:-}
 
 make -j"${CPU_COUNT:-1}"
 make install
@@ -164,7 +162,7 @@ if [ ! -z "$build_with_cuda" ]; then
     echo "pml = ^ucx" >> $PREFIX/etc/openmpi-mca-params.conf
     echo "setting the mca osc to ^ucx..."
     echo "osc = ^ucx" >> $PREFIX/etc/openmpi-mca-params.conf
-    
+
     POST_LINK=$PREFIX/bin/.openmpi-post-link.sh
     cp $RECIPE_DIR/post-link.sh $POST_LINK
     chmod +x $POST_LINK

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,12 @@
 mpi_type:
   - external
   - conda
+
+# rather than rebuilding the full compiler matrix
+# we disable conda-smithy's cuda detection,
+# and only re-add the necessary cuda versions to be used with the default compilers
+
+cuda_compiler_version:  # [linux64]
+  - 10.2  # [linux64]
+docker_image:  # [linux64]
+  - quay.io/condaforge/linux-anvil-cos7-cuda:10.2  # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,15 @@
 {% set version = "4.1.3" %}
 {% set major = version.rpartition('.')[0] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}
 {% set build = build + 100 %}
 {% endif %}
+
+# avoid conda-forge's cuda compiler detection
+# which forces a complex build matrix
+{% set cooda = 'cuda' %}
 
 package:
   # must not match any outputs for requirements to be handled correctly
@@ -19,8 +23,8 @@ source:
 
 build:
   number: {{ build }}
-  # remember to bump the CUDA version in build-mpi.sh too!
-  skip: true  # [win or (linux64 and cuda_compiler_version != '10.2') or ((aarch64 or ppc64le) and cuda_compiler_version not in (undefined, "None"))]
+  number: 1
+  skip: true  # [win]
 
 outputs:
   {% if mpi_type == 'external' %}
@@ -41,13 +45,13 @@ outputs:
       run_exports:
         - {{ pin_subpackage('openmpi', min_pin='x.x.x', max_pin='x') }}
       ignore_run_exports_from:
-        - {{ compiler('cuda') }}  # [linux64]
+        - {{ compiler(cooda) }}  # [linux64]
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ compiler('fortran') }}
-        - {{ compiler('cuda') }}  # [linux64]
+        - {{ compiler(cooda) }}  # [linux64]
         - autoconf  # [unix]
         - automake  # [unix]
         - libtool   # [unix]
@@ -61,7 +65,7 @@ outputs:
         - zlib
         - mpi 1.0 openmpi
       run_constrained:
-        - cudatoolkit >=9.2  # [linux64]
+        - cudatoolkit >={{ cuda_compiler_version }}  # [linux64]
         - ucx 1.9.0  # [linux64]
     test:
       script: run_test.sh


### PR DESCRIPTION
Because cuda compilers are matrix-aligned with other compilers (c, fortran, etc.), skipping all but an old cuda compiler version means pinning all compilers to old versions. As far as I know, this is only a problem for gfortran, where gfortran 7 emits a dependency on libgfortran 4, while gfortran 10 emits a dependency on libgfortran 5, making their build products mutually exclusive at install time (i.e. #94 means openmpi 4.1.3 cannot be installed along with any other package compiled with the current default fortran on conda-forge).

- specify cuda_compiler_version explicitly instead of via skips
- avoid duplicating version in multiple places, which should prevent future instances of #84 
- some template shenanigans ('cooda') to avoid pulling in the cuda_compiler zip_keys build matrix. I'm not 100% sure this will work. If not, I think we'll have to subset every entry in the compiler zip_keys lists, which will be tedious to maintain.

closes #94
