### PR TITLE
Change maintainer username from @astrofrog-conda-forge to @astrofrog

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -35,11 +35,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/linux_64_mpi_typeconda.yaml
+++ b/.ci_support/linux_64_mpi_typeconda.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 enable_cuda:
@@ -21,7 +21,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - conda
 target_platform:

--- a/.ci_support/linux_64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_mpi_typeexternal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -13,7 +13,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 enable_cuda:
@@ -21,7 +21,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - external
 target_platform:

--- a/.ci_support/linux_aarch64_mpi_typeconda.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeconda.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64-cuda:11.0
 enable_cuda:
@@ -25,7 +25,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - conda
 target_platform:

--- a/.ci_support/linux_aarch64_mpi_typeexternal.yaml
+++ b/.ci_support/linux_aarch64_mpi_typeexternal.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64-cuda:11.0
 enable_cuda:
@@ -25,7 +25,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - external
 target_platform:

--- a/.ci_support/linux_ppc64le_mpi_typeconda.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeconda.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.0
 enable_cuda:
@@ -21,7 +21,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - conda
 target_platform:

--- a/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
+++ b/.ci_support/linux_ppc64le_mpi_typeexternal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ cudatoolkit:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le-cuda:11.0
 enable_cuda:
@@ -21,7 +21,7 @@ enable_cuda:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 mpi_type:
 - external
 target_platform:

--- a/.ci_support/migrations/ucx1410.yaml
+++ b/.ci_support/migrations/ucx1410.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-ucx:
-- '1.14.0'
-migrator_ts: 1679152574.207815

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 enable_cuda:
 - 'False'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi_type:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 enable_cuda:
 - 'False'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi_type:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astrofrog-conda-forge @beckermr @bekozi @dalcinl @leofang @minrk @msarahan @ocefpaf
+* @astrofrog @beckermr @bekozi @dalcinl @leofang @minrk @msarahan @ocefpaf

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
+* [@astrofrog](https://github.com/astrofrog/)
 * [@beckermr](https://github.com/beckermr/)
 * [@bekozi](https://github.com/bekozi/)
 * [@dalcinl](https://github.com/dalcinl/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -141,7 +141,7 @@ about:
 
 extra:
   recipe-maintainers:
-    - astrofrog-conda-forge
+    - astrofrog
     - bekozi
     - dalcinl
     - leofang


### PR DESCRIPTION
This is to update my username from @astrofrog-conda-forge to @astrofrog - I used to have a separate username back when being a member of any conda-forge repository meant that I saw all conda-forge repositories on Travis CI but this is no longer relevant.

@conda-forge-admin please rerender