### PR TITLE
Fix missing libcuda warning

### DIFF
--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -167,6 +167,8 @@ if [ -n "$build_with_ucx" ]; then
     cat $RECIPE_DIR/post-link-ucx.sh >> $POST_LINK
 fi
 if [ -n "$build_with_cuda" ]; then
+    echo "setting MCA mca_base_component_show_load_errors to 0..."
+    echo "mca_base_component_show_load_errors = 0" >> $PREFIX/etc/openmpi-mca-params.conf
     echo "setting MCA opal_warn_on_missing_libcuda to 0..."
     echo "opal_warn_on_missing_libcuda = 0" >> $PREFIX/etc/openmpi-mca-params.conf
     echo "setting MCA opal_cuda_support to 0..."

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "5.0.0" %}
 {% set major = version.rpartition('.')[0] %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

See https://github.com/conda-forge/openmpi-feedstock/pull/132#issuecomment-1868373443