### PR TITLE
Add `sysroot` to `requirements/build`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -35,6 +35,27 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
+  - script: |
+         sudo mkdir -p /opt/empty_dir || true
+         for d in \
+                  /opt/ghc \
+                  /opt/hostedtoolcache \
+                  /usr/lib/jvm \
+                  /usr/local/.ghcup \
+                  /usr/local/lib/android \
+                  /usr/local/share/powershell \
+                  /usr/share/dotnet \
+                  /usr/share/swift \
+                  ; do
+           sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+         done
+         sudo apt-get purge -y -f firefox \
+                                  google-chrome-stable \
+                                  microsoft-edge-stable
+         sudo apt-get autoremove -y >& /dev/null
+         sudo apt-get autoclean -y >& /dev/null
+         df -h
+    displayName: Manage disk space
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+azure:
+  free_disk_space: true
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ compiler('cuda') }}     # [cuda_compiler != "None"]
         - {{ compiler('fortran') }}
+        - sysroot_{{ target_platform }} 2.17  # [linux]
         #- autoconf  # [unix]
         #- automake  # [unix]
         - libtool   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.1" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}


### PR DESCRIPTION
In PR ( https://github.com/conda-forge/openmpi-feedstock/pull/121 ), the `linux-64` builds were updated to an image based on CentOS 7, which was mentioned here ( https://github.com/conda-forge/openmpi-feedstock/pull/121#discussion_r1443658627 ). However the packages don't currently factor this into the `__glibc` version constraint

This PR fixes that by adding the `sysroot` package pinned to `2.17`, which is what CentOS 7 uses. As [`sysroot` has a `__glibc` `run_exports/strong` constraint]( https://github.com/conda-forge/linux-sysroot-feedstock/blob/3098c5868c9c32b077137b746e574f8e137b69e3/recipe/meta.yaml#L124-L126 ), this is added to the `build` & `host` environment as well as the final package dependencies

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
