### PR TITLE
ENH ensure external variants have same deps as regular ones for the solver

### DIFF
--- a/.ci_support/migrations/libhwloc2100.yaml
+++ b/.ci_support/migrations/libhwloc2100.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for libhwloc 2.10.0
-  kind: version
-  migration_number: 1
-libhwloc:
-- 2.10.0
-migrator_ts: 1711507406.8423882

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,19 @@ build:
   skip: true  # [linux and cuda_compiler_version != "11.8"]
 
 outputs:
-  {% if mpi_type == 'conda' %}
   - name: openmpi
+    {% if mpi_type == 'conda' %}
     script: build-mpi.sh
+    {% endif %}
     build:
+      {% if mpi_type == 'conda' %}
       run_exports:
         - {{ pin_subpackage('openmpi', min_pin='x.x.x', max_pin='x') }}
+      {% else %}
+      string: {{ mpi_type }}_h{{ PKG_HASH }}_{{ build }}
+      track_features:
+        - openmpi_{{ mpi_type }}
+      {% endif %}
       ignore_run_exports:
         - ucx  # [linux]
       ignore_run_exports_from:
@@ -65,10 +72,16 @@ outputs:
         # Ensure a consistent CUDA environment
         - cuda-version  >= {{ cuda_major ~ ".0" }}  # [cuda_compiler != "None"]
     test:
+      {% if mpi_type == 'conda' %}
       script: run_test.sh
       files:
         - tests/helloworld.sh
+      {% else %}
+      commands:
+        - echo "It works!"
+      {% endif %}
 
+  {% if mpi_type == 'conda' %}
   - name: openmpi-mpicc
     build:
       script:
@@ -125,19 +138,6 @@ outputs:
       files:
         - tests/helloworld.f
         - tests/helloworld.f90
-  {% else %}
-  - name: openmpi
-    build:
-      string: {{ mpi_type }}_{{ build }}
-      track_features:
-        - openmpi_{{ mpi_type }}
-    requirements:
-      host: []
-      run:
-        - mpi 1.0 openmpi
-    test:
-      commands:
-        - echo "It works!"
   {% endif %}
 
 about:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref #153 

I am hoping this will help with #153 above in that the external builds will be identical expect that they are shells, have an extra feature, and a lower build number. This should help the solver deprioritize them properly. If this works, we'd need to possibly mark some of the older 5.x ones broken.
