### PR TITLE
set environment in activate.sh for conda-build

### DIFF
--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -95,4 +95,4 @@ if [ -f $POST_LINK ]; then
 fi
 
 mkdir -p $PREFIX/etc/conda/activate.d
-cp -v $RECIPE/openmpi_activate.sh $PREFIX/etc/conda/activate.d/
+cp -v $RECIPE_DIR/openmpi_activate.sh $PREFIX/etc/conda/activate.d/

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -93,3 +93,6 @@ fi
 if [ -f $POST_LINK ]; then
     chmod +x $POST_LINK
 fi
+
+mkdir -p $PREFIX/etc/conda/activate.d
+cp -v $RECIPE/openmpi_activate.sh $PREFIX/etc/conda/activate.d/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 3 %}
+{% set build = 4 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -1,0 +1,8 @@
+if [[ "${CONDA_BUILD:-}" = "1" ]]; then
+  echo "setting openmpi environment variables for conda-build"
+  export OMPI_MCA_plm_ssh_agent=false
+  export OMPI_MCA_pml=ob1
+  export OMPI_MCA_mpi_yield_when_idle=true
+  export OMPI_MCA_btl_base_warn_component_unused=false
+  export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
+fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -ex
 
-export OMPI_MCA_pml=ob1
-export OMPI_MCA_btl=sm,self
-export OMPI_MCA_plm_ssh_agent=false
-export OMPI_MCA_rmaps_default_mapping_policy=:oversubscribe
-export OMPI_ALLOW_RUN_AS_ROOT=1
-export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 MPIEXEC="mpiexec"
 
 pushd "tests"


### PR DESCRIPTION
this should avoid the tedious requirement to set a bunch of ever-changing environment variables in every package that builds against openmpi

I did not copy allow_root, which appears to no longer be necessary with latest conda-forge infrastructure