### PR TITLE
add wrapper compiler flags in CONDA_BUILD, install .mod in include

### DIFF
--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -73,6 +73,10 @@ fi
 make -j"${CPU_COUNT:-1}"
 make install
 
+# openmpi installs .mod files in the wrong prefix (/lib instead of /include)
+ls -l $PREFIX/lib/*.mod
+mv -v $PREFIX/lib/*.mod $PREFIX/include/
+
 POST_LINK=$PREFIX/bin/.openmpi-post-link.sh
 if [ -n "$build_with_ucx" ]; then
     echo "setting MCA pml to ^ucx..."

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -74,8 +74,11 @@ make -j"${CPU_COUNT:-1}"
 make install
 
 # openmpi installs .mod files in the wrong prefix (/lib instead of /include)
-ls -l $PREFIX/lib/*.mod
-mv -v $PREFIX/lib/*.mod $PREFIX/include/
+# symlink instead of copy to avoid breaking anything (unlikely)
+for f in $PREFIX/lib/*.mod; do
+  modname=$(basename "$f")
+  ln -sv "../lib/${modname}" "$PREFIX/include/${modname}"
+done
 
 POST_LINK=$PREFIX/bin/.openmpi-post-link.sh
 if [ -n "$build_with_ucx" ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -6,6 +6,7 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
       declare -x "OMPI_${_var}=${!_var}"
     fi
   done
+  export OPAL_PREFIX="$PREFIX"
 
   # runtime variables
   export OMPI_MCA_plm_ssh_agent=false

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -7,7 +7,8 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
       export OMPI_${_var}="${!_var}"
     fi
     if [[ -z "${OMPI_FCFLAGS}" && ! -z "${FFLAGS}" ]]; then
-      export OMPI_FCFLAGS="$FFLAGS"
+      echo OMPI_FCFLAGS="-I$PREFIX/include $FFLAGS"
+      export OMPI_FCFLAGS="-I$PREFIX/include $FFLAGS"
     fi
   done
   export OPAL_PREFIX="$PREFIX"

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -4,7 +4,7 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
   for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do
     if [[ ! -z "${!_var:-}" ]]; then
       echo "OMPI_${_var}=${!_var}"
-      declare -gx "OMPI_${_var}=${!_var}"
+      export OMPI_${_var}="${!_var}"
     fi
   done
   export OPAL_PREFIX="$PREFIX"

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -6,6 +6,9 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
       echo "OMPI_${_var}=${!_var}"
       export OMPI_${_var}="${!_var}"
     fi
+    if [[ -z "${OMPI_FCFLAGS}" && ! -z "${FFLAGS}" ]]; then
+      export OMPI_FCFLAGS="$FFLAGS"
+    fi
   done
   export OPAL_PREFIX="$PREFIX"
 

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -1,5 +1,13 @@
 if [[ "${CONDA_BUILD:-}" = "1" ]]; then
   echo "setting openmpi environment variables for conda-build"
+  # build-time variables
+  for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do
+    if [[ ! -z "${!_var:-}" ]]; then
+      declare -x OMPI_${_var}=${!_var}
+    fi
+  done
+
+  # runtime variables
   export OMPI_MCA_plm_ssh_agent=false
   export OMPI_MCA_pml=ob1
   export OMPI_MCA_mpi_yield_when_idle=true

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -3,7 +3,8 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
   # build-time variables
   for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do
     if [[ ! -z "${!_var:-}" ]]; then
-      declare -x "OMPI_${_var}=${!_var}"
+      echo "OMPI_${_var}=${!_var}"
+      declare -gx "OMPI_${_var}=${!_var}"
     fi
   done
   export OPAL_PREFIX="$PREFIX"

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -3,7 +3,7 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
   # build-time variables
   for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do
     if [[ ! -z "${!_var:-}" ]]; then
-      declare -x OMPI_${_var}=${!_var}
+      declare -x "OMPI_${_var}=${!_var}"
     fi
   done
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -26,6 +26,9 @@ if [[ $PKG_NAME == "openmpi" ]]; then
   command -v mpiexec
   $MPIEXEC --help
   $MPIEXEC -n 4 ./helloworld.sh
+
+  test -f $PREFIX/include/mpi.mod
+  test ! -f $PREFIX/include/mpi.mod
 fi
 
 if [[ $PKG_NAME == "openmpi-mpicc" ]]; then

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -32,7 +32,12 @@ if [[ $PKG_NAME == "openmpi-mpicc" ]]; then
   command -v mpicc
   mpicc -show
 
-  mpicc $CFLAGS $LDFLAGS helloworld.c -o helloworld_c
+  test ! -z "${OMPI_CC:-}"
+  test ! -z "${OMPI_CFLAGS:-}"
+  test ! -z "${OMPI_CPPFLAGS:-}"
+  test ! -z "${OMPI_LDFLAGS:-}"
+
+  mpicc helloworld.c -o helloworld_c
   $MPIEXEC -n 4 ./helloworld_c
 fi
 
@@ -40,30 +45,36 @@ if [[ $PKG_NAME == "openmpi-mpicxx" ]]; then
   command -v mpicxx
   mpicxx -show
 
-  mpicxx $CXXFLAGS $LDFLAGS helloworld.cxx -o helloworld_cxx
+  test ! -z "${OMPI_CXX:-}"
+  test ! -z "${OMPI_CXXFLAGS:-}"
+
+  mpicxx helloworld.cxx -o helloworld_cxx
   $MPIEXEC -n 4 ./helloworld_cxx
 fi
 
 if [[ $PKG_NAME == "openmpi-mpifort" ]]; then
   command -v mpifort
   mpifort -show
+  
+  test ! -z "${OMPI_FC:-}"
+  test ! -z "${OMPI_FCFLAGS:-}"
 
-  mpifort $FFLAGS $LDFLAGS helloworld.f -o helloworld1_f
+  mpifort helloworld.f -o helloworld1_f
   $MPIEXEC -n 4 ./helloworld1_f
 
-  mpifort $FFLAGS $LDFLAGS helloworld.f90 -o helloworld1_f90
+  mpifort helloworld.f90 -o helloworld1_f90
   $MPIEXEC -n 4 ./helloworld1_f90
 
   command -v mpif77
   mpif77 -show
 
-  mpif77 $FFLAGS $LDFLAGS helloworld.f -o helloworld2_f
+  mpif77 helloworld.f -o helloworld2_f
   $MPIEXEC -n 4 ./helloworld2_f
 
   command -v mpif90
   mpif90 -show
 
-  mpif90 $FFLAGS $LDFLAGS helloworld.f90 -o helloworld2_f90
+  mpif90 helloworld.f90 -o helloworld2_f90
   $MPIEXEC -n 4 ./helloworld2_f90
 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -28,7 +28,7 @@ if [[ $PKG_NAME == "openmpi" ]]; then
   $MPIEXEC -n 4 ./helloworld.sh
 
   test -f $PREFIX/include/mpi.mod
-  test ! -f $PREFIX/include/mpi.mod
+  test ! -f $PREFIX/lib/mpi.mod
 fi
 
 if [[ $PKG_NAME == "openmpi-mpicc" ]]; then

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -35,6 +35,8 @@ if [[ $PKG_NAME == "openmpi-mpicc" ]]; then
   command -v mpicc
   mpicc -show
 
+  env | grep OMPI
+
   test ! -z "${OMPI_CC:-}"
   test ! -z "${OMPI_CFLAGS:-}"
   test ! -z "${OMPI_CPPFLAGS:-}"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -28,7 +28,8 @@ if [[ $PKG_NAME == "openmpi" ]]; then
   $MPIEXEC -n 4 ./helloworld.sh
 
   test -f $PREFIX/include/mpi.mod
-  test ! -f $PREFIX/lib/mpi.mod
+  # keep duplicates in original location for now
+  test -f $PREFIX/lib/mpi.mod
 fi
 
 if [[ $PKG_NAME == "openmpi-mpicc" ]]; then


### PR DESCRIPTION
openmpi appears to be the only fortran package that puts .mod files in $PREFIX/lib, which is not found by default, so move them to include like everybody else, so gfortran finds them with standard include flags.

Without this, some situations (only found so far in mac cross-compile) need `-I$PREFIX/lib` to find fortran modules.

also ensures that OMPI_CC=$CC and friends are set in conda-build, which is generally necessary for cross-compilation and should now be more likely to work by default.

found via https://github.com/conda-forge/scalapack-feedstock/pull/34