### PR TITLE
only set wrapper args for cross compilation, keeping subset of LDFLAGS necessary for sysroot < 2.17

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      ? linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda
-      : CONFIG: linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda
+      ? linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda
+      : CONFIG: linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
-      ? linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal
-      : CONFIG: linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal
+      ? linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal
+      : CONFIG: linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cuda:11.8
       ? linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
@@ -46,4 +46,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
@@ -46,4 +46,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
@@ -50,4 +50,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
@@ -50,4 +50,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda.yaml
@@ -46,4 +46,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal.yaml
@@ -46,4 +46,4 @@ zip_keys:
   - cuda_compiler_version
   - docker_image
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -41,4 +41,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 zlib:
-- '1.2'
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -41,4 +41,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 zlib:
-- '1.2'
+- '1'

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda</td>
+              <td>linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeconda" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal</td>
+              <td>linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=720&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11c_stdlib_version2.17cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/openmpi-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpi_typeexternal" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,6 +12,8 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
+os_version:
+  linux_64: cos7
 provider:
   linux_aarch64: default
   linux_ppc64le: default

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,6 +14,8 @@ github:
   tooling_branch_name: main
 os_version:
   linux_64: cos7
+  linux_aarch64: cos7
+  linux_ppc64le: cos7
 provider:
   linux_aarch64: default
   linux_ppc64le: default

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -11,6 +11,7 @@ export FC=$(basename "$FC")
 unset FFLAGS F77 F90 F95
 
 # tweak compiler flags
+wrapper_ldflags="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export LIBRARY_PATH="$PREFIX/lib"
 if [[ "$target_platform" == osx-* ]]; then
     if [[ -n "$CONDA_BUILD_SYSROOT" ]]; then
@@ -23,6 +24,9 @@ fi
 build_with_ucx=""
 if [[ "$target_platform" == linux-* ]]; then
     build_with_ucx="--with-ucx=$PREFIX"
+    # allow-shlib-undefined required for dependencies to link against older sysroot
+    # avoids undefined
+    wrapper_ldflags="${wrapper_ldflags} -Wl,--allow-shlib-undefined"
 fi
 
 # CUDA support
@@ -60,7 +64,7 @@ fi
             --with-wrapper-cflags="-I$PREFIX/include" \
             --with-wrapper-cxxflags="-I$PREFIX/include" \
             --with-wrapper-fcflags="-I$PREFIX/include" \
-            --with-wrapper-ldflags="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib" \
+            --with-wrapper-ldflags="${wrapper_ldflags}" \
             --with-sge \
             --with-hwloc=$PREFIX \
             --with-libevent=$PREFIX \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,3 @@
-c_stdlib_version:  # [linux]
-  - 2.17           # [linux]
-
 mpi_type:
   - external  # [linux]
   - conda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -24,6 +24,9 @@ if [[ "${CONDA_BUILD:-}" = "1" ]]; then
     if [[ -z "${OMPI_LDFLAGS:-}" ]]; then
       # pkg-config --libs-only-L --libs-only-other ompi
       export OMPI_LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+      if [[ "${target_platform:-}" == linux-* ]]; then
+        export OMPI_LDFLAGS="${OMPI_LDFLAGS} -Wl,--allow-shlib-undefined"
+      fi
     fi
     export OPAL_PREFIX="$PREFIX"
   fi

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -1,17 +1,32 @@
 if [[ "${CONDA_BUILD:-}" = "1" ]]; then
   echo "setting openmpi environment variables for conda-build"
-  # build-time variables
-  for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do
-    if [[ ! -z "${!_var:-}" ]]; then
-      echo "OMPI_${_var}=${!_var}"
-      export OMPI_${_var}="${!_var}"
+  if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" = "1" ]]; then
+    # set compilation variables during cross compilation
+    for _var in CC CXX FC; do
+      if [[ ! -z "${!_var:-}" ]]; then
+        echo "OMPI_${_var}=${!_var}"
+        export OMPI_${_var}="${!_var}"
+      fi
+    done
+    # require pkg-config?
+    if [[ -z "${OMPI_CFLAGS:-}" ]]; then
+      # pkg-config --cflags ompi
+      export OMPI_CFLAGS="-I$PREFIX/include"
     fi
-    if [[ -z "${OMPI_FCFLAGS}" && ! -z "${FFLAGS}" ]]; then
-      echo OMPI_FCFLAGS="-I$PREFIX/include $FFLAGS"
-      export OMPI_FCFLAGS="-I$PREFIX/include $FFLAGS"
+    if [[ -z "${OMPI_CXXFLAGS:-}" ]]; then
+      # pkg-config --cflags ompi-cxx
+      export OMPI_CXXFLAGS="-I$PREFIX/include"
     fi
-  done
-  export OPAL_PREFIX="$PREFIX"
+    if [[ -z "${OMPI_FCFLAGS:-}" ]]; then
+      # pkg-config --cflags ompi-fort
+      export OMPI_FCFLAGS="-I$PREFIX/include"
+    fi
+    if [[ -z "${OMPI_LDFLAGS:-}" ]]; then
+      # pkg-config --libs-only-L --libs-only-other ompi
+      export OMPI_LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+    fi
+    export OPAL_PREFIX="$PREFIX"
+  fi
 
   # runtime variables
   export OMPI_MCA_plm_ssh_agent=false

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -2,12 +2,21 @@ if [ "${CONDA_BUILD:-}" = "1" ]; then
   echo "setting openmpi environment variables for conda-build"
   if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" = "1" ]]; then
     # set compilation variables during cross compilation
-    for _var in CC CXX FC; do
-      if [[ ! -z "${!_var:-}" ]]; then
-        echo "OMPI_${_var}=${!_var}"
-        export OMPI_${_var}="${!_var}"
-      fi
-    done
+    if [[ -z "${OMPI_CC:-}" && ! -z "${CC:-}" ]]; then
+      echo "OMPI_CC=${CC}"
+      export "OMPI_CC=${CC}"
+    fi
+
+    if [[ -z "${OMPI_CXX:-}" && ! -z "${CXX:-}" ]]; then
+      echo "OMPI_CXX=${CXX}"
+      export "OMPI_CXX=${CXX}"
+    fi
+
+    if [[ -z "${OMPI_FC:-}" && ! -z "${FC:-}" ]]; then
+      echo "OMPI_FC=${FC}"
+      export "OMPI_FC=${FC}"
+    fi
+
     # require pkg-config?
     if [[ -z "${OMPI_CFLAGS:-}" ]]; then
       # pkg-config --cflags ompi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -43,7 +43,7 @@ if [[ $PKG_NAME == "openmpi-mpicc" ]]; then
   test -z "${OMPI_CPPFLAGS:-}"
   test -z "${OMPI_LDFLAGS:-}"
 
-  mpicc helloworld.c -o helloworld_c
+  mpicc $CFLAGS $LDFLAGS helloworld.c -o helloworld_c
   $MPIEXEC -n 4 ./helloworld_c
 fi
 
@@ -54,7 +54,7 @@ if [[ $PKG_NAME == "openmpi-mpicxx" ]]; then
   test -z "${OMPI_CXX:-}"
   test -z "${OMPI_CXXFLAGS:-}"
 
-  mpicxx helloworld.cxx -o helloworld_cxx
+  mpicxx $CXXFLAGS $LDFLAGS helloworld.cxx -o helloworld_cxx
   $MPIEXEC -n 4 ./helloworld_cxx
 fi
 
@@ -65,22 +65,22 @@ if [[ $PKG_NAME == "openmpi-mpifort" ]]; then
   test -z "${OMPI_FC:-}"
   test -z "${OMPI_FCFLAGS:-}"
 
-  mpifort helloworld.f -o helloworld1_f
+  mpifort $FFLAGS $LDFLAGS helloworld.f -o helloworld1_f
   $MPIEXEC -n 4 ./helloworld1_f
 
-  mpifort helloworld.f90 -o helloworld1_f90
+  mpifort $FFLAGS $LDFLAGS helloworld.f90 -o helloworld1_f90
   $MPIEXEC -n 4 ./helloworld1_f90
 
   command -v mpif77
   mpif77 -show
 
-  mpif77 helloworld.f -o helloworld2_f
+  mpif77 $FFLAGS $LDFLAGS helloworld.f -o helloworld2_f
   $MPIEXEC -n 4 ./helloworld2_f
 
   command -v mpif90
   mpif90 -show
 
-  mpif90 helloworld.f90 -o helloworld2_f90
+  mpif90 $FFLAGS $LDFLAGS helloworld.f90 -o helloworld2_f90
   $MPIEXEC -n 4 ./helloworld2_f90
 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -43,7 +43,7 @@ if [[ $PKG_NAME == "openmpi-mpicc" ]]; then
   test -z "${OMPI_CPPFLAGS:-}"
   test -z "${OMPI_LDFLAGS:-}"
 
-  mpicc $CFLAGS $LDFLAGS helloworld.c -o helloworld_c
+  mpicc helloworld.c -o helloworld_c
   $MPIEXEC -n 4 ./helloworld_c
 fi
 
@@ -54,7 +54,7 @@ if [[ $PKG_NAME == "openmpi-mpicxx" ]]; then
   test -z "${OMPI_CXX:-}"
   test -z "${OMPI_CXXFLAGS:-}"
 
-  mpicxx $CXXFLAGS $LDFLAGS helloworld.cxx -o helloworld_cxx
+  mpicxx helloworld.cxx -o helloworld_cxx
   $MPIEXEC -n 4 ./helloworld_cxx
 fi
 
@@ -65,22 +65,22 @@ if [[ $PKG_NAME == "openmpi-mpifort" ]]; then
   test -z "${OMPI_FC:-}"
   test -z "${OMPI_FCFLAGS:-}"
 
-  mpifort $FFLAGS $LDFLAGS helloworld.f -o helloworld1_f
+  mpifort helloworld.f -o helloworld1_f
   $MPIEXEC -n 4 ./helloworld1_f
 
-  mpifort $FFLAGS $LDFLAGS helloworld.f90 -o helloworld1_f90
+  mpifort helloworld.f90 -o helloworld1_f90
   $MPIEXEC -n 4 ./helloworld1_f90
 
   command -v mpif77
   mpif77 -show
 
-  mpif77 $FFLAGS $LDFLAGS helloworld.f -o helloworld2_f
+  mpif77 helloworld.f -o helloworld2_f
   $MPIEXEC -n 4 ./helloworld2_f
 
   command -v mpif90
   mpif90 -show
 
-  mpif90 $FFLAGS $LDFLAGS helloworld.f90 -o helloworld2_f90
+  mpif90 helloworld.f90 -o helloworld2_f90
   $MPIEXEC -n 4 ./helloworld2_f90
 
 fi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -38,10 +38,10 @@ if [[ $PKG_NAME == "openmpi-mpicc" ]]; then
 
   env | grep OMPI
 
-  test ! -z "${OMPI_CC:-}"
-  test ! -z "${OMPI_CFLAGS:-}"
-  test ! -z "${OMPI_CPPFLAGS:-}"
-  test ! -z "${OMPI_LDFLAGS:-}"
+  test -z "${OMPI_CC:-}"
+  test -z "${OMPI_CFLAGS:-}"
+  test -z "${OMPI_CPPFLAGS:-}"
+  test -z "${OMPI_LDFLAGS:-}"
 
   mpicc helloworld.c -o helloworld_c
   $MPIEXEC -n 4 ./helloworld_c
@@ -51,8 +51,8 @@ if [[ $PKG_NAME == "openmpi-mpicxx" ]]; then
   command -v mpicxx
   mpicxx -show
 
-  test ! -z "${OMPI_CXX:-}"
-  test ! -z "${OMPI_CXXFLAGS:-}"
+  test -z "${OMPI_CXX:-}"
+  test -z "${OMPI_CXXFLAGS:-}"
 
   mpicxx helloworld.cxx -o helloworld_cxx
   $MPIEXEC -n 4 ./helloworld_cxx
@@ -62,8 +62,8 @@ if [[ $PKG_NAME == "openmpi-mpifort" ]]; then
   command -v mpifort
   mpifort -show
   
-  test ! -z "${OMPI_FC:-}"
-  test ! -z "${OMPI_FCFLAGS:-}"
+  test -z "${OMPI_FC:-}"
+  test -z "${OMPI_FCFLAGS:-}"
 
   mpifort helloworld.f -o helloworld1_f
   $MPIEXEC -n 4 ./helloworld1_f


### PR DESCRIPTION
defaults are not likely to be wrong for native compilation, don't mess with them, I think #158 went a bit too far.

and don't passthrough $LDFLAGS, etc. from compiler activation, set the actual correct values from the wrappers with the right prefix.

closes #163 
