### PR TITLE
Make activate script POSIX-compatible.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}

--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -1,4 +1,4 @@
-if [[ "${CONDA_BUILD:-}" = "1" ]]; then
+if [ "${CONDA_BUILD:-}" = "1" ]; then
   echo "setting openmpi environment variables for conda-build"
   # build-time variables
   for _var in CC CXX FC CPPFLAGS CFLAGS CXXFLAGS FCFLAGS LDFLAGS; do


### PR DESCRIPTION
The activate script can be run in a number of shells, not just bash, so it should only use POSIX-compatible syntax.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
