### PR TITLE
Add --enable-ipv6 flag to build-mpi.sh configure

### DIFF
--- a/.ci_support/migrations/libhwloc2110.yaml
+++ b/.ci_support/migrations/libhwloc2110.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for libhwloc 2.11.0
-  kind: version
-  migration_number: 1
-libhwloc:
-- 2.11.0
-migrator_ts: 1719349281.82988

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -70,6 +70,7 @@ fi
             --with-libevent=$PREFIX \
             --with-zlib=$PREFIX \
             --enable-mca-dso \
+            --enable-ipv6 \
             $build_with_ucx \
             $build_with_cuda \
     || (cat config.log; false)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.3" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 9 %}
+{% set build = 10 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #165 
<!--
Please add any other relevant info below:
-->
