### PR TITLE
backport patch fixing MPIEXEC_TIMEOUT support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.5" %}
 {% set major = version.rpartition('.')[0] %}
 {% set cuda_major = (cuda_compiler_version|default("11.8")).rpartition('.')[0] %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # give conda package a higher build number
 {% if mpi_type == 'conda' %}
@@ -19,6 +19,7 @@ source:
   sha256: 6588d57c0a4bd299a24103f4e196051b29e8b55fbda49e11d5b3d32030a32776
   patches:
     - ldflags-mac.patch  # [osx]
+    - prrte-mpiexec-timeout.patch
 
 build:
   number: {{ build }}

--- a/recipe/prrte-mpiexec-timeout.patch
+++ b/recipe/prrte-mpiexec-timeout.patch
@@ -1,0 +1,42 @@
+From 5e3e8bf91d47db5134d73004a12dbe16984a461c Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Tue, 1 Oct 2024 11:49:36 +0200
+Subject: [PATCH] 3.0: fix support for MPIEXEC_TIMEOUT
+
+linter fix for comparison of int to uint resulted in MPIEXEC_TIMEOUT env being ignored
+
+---
+ src/tools/prte/prte.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/3rd-party/prrte/src/tools/prte/prte.c b/3rd-party/prrte/src/tools/prte/prte.c
+index 62ff748566..5c1b7473cc 100644
+--- a/3rd-party/prrte/src/tools/prte/prte.c
++++ b/3rd-party/prrte/src/tools/prte/prte.c
+@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
+     pmix_info_t *iptr, *iptr2, info;
+     pmix_status_t ret;
+     bool flag;
+-    size_t n, m, ninfo, param_len;
++    size_t n, ninfo, param_len;
+     pmix_app_t *papps;
+     size_t napps;
+     mylock_t mylock;
+@@ -1085,11 +1085,11 @@ int main(int argc, char *argv[])
+     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_TIMEOUT);
+     if (NULL != opt || NULL != (timeoutenv = getenv("MPIEXEC_TIMEOUT"))) {
+         if (NULL != timeoutenv) {
+-            m = strtoul(timeoutenv, NULL, 10);
++            i = strtol(timeoutenv, NULL, 10);
+             /* both cannot be present, or they must agree */
+             if (NULL != opt) {
+-                n = strtoul(opt->values[0], NULL, 10);
+-                if (m != n) {
++                n = strtol(opt->values[0], NULL, 10);
++                if (i != (int)n) {
+                     pmix_show_help("help-prun.txt", "prun:timeoutconflict", false,
+                                    prte_tool_basename, n, timeoutenv);
+                     PRTE_UPDATE_EXIT_STATUS(1);
+-- 
+2.45.0
+

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -42,6 +42,13 @@ if [[ $PKG_NAME == "openmpi" ]]; then
   $MPIEXEC -n 4 ./helloworld.sh
 
   test -f $PREFIX/include/mpi.mod
+
+  export MPIEXEC_TIMEOUT=1
+
+  if $MPIEXEC -n 2 sleep 5; then
+    echo "should have timed out"
+    exit 1
+  fi
 fi
 
 if [[ $PKG_NAME == "openmpi-mpicc" ]]; then


### PR DESCRIPTION
setting MPIEXEC_TIMEOUT to anything results in a timeout of 14 seconds: https://github.com/open-mpi/ompi/issues/12837