### PR TITLE
avoid bashisms in openmpi-activate again

### DIFF
--- a/recipe/openmpi_activate.sh
+++ b/recipe/openmpi_activate.sh
@@ -1,6 +1,8 @@
 # rattler-build sets PKG_NAME, not CONDA_BUILD in test env
 # ref: https://github.com/prefix-dev/rattler-build/issues/1317
-if [[ "${CONDA_BUILD:-}" = "1" || -n "${PKG_NAME:-}" ]]; then
+# note: this first `if` must remain POSIX-compatible (no bash [[]])
+# (inner content can be bash, since conda-build env shells are bash by definition)
+if [ "${CONDA_BUILD:-}" = "1" ] || [ "${PKG_NAME:-}" != "" ]; then
   echo "setting openmpi environment variables for conda-build"
   if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" = "1" ]]; then
     # set compilation variables during cross compilation

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: 5.0.8
-  build: 106
+  build: 107
   mpi_type: ${{ mpi_type | default('conda') }}
   major_minor: ${{ (version | split('.'))[:2] | join('.') }}
   cuda_compiler_version: ${{ cuda_compiler_version | default('None') }}

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -ex
 
+# validate sh-safety of activate script (no bash-isms)
+(
+  CONDA_BUILD=""
+  PKG_NAME=""
+  /bin/sh -e "$PREFIX/etc/conda/activate.d/openmpi_activate.sh"
+)
+
 MPIEXEC="mpiexec"
 
 pushd "tests"


### PR DESCRIPTION
and try to validate this so we don't do it again

same as #162, but again since I introduced another bash-ism to check $PKG_NAME. I added a test that should hopefully catch this in the future and a comment so I hopefully don't do it again
